### PR TITLE
Update Readme whit working spinner

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ yarn add vue-loading-spinner
 ``` vue
 <template>
   <div id="app">
-    <cube-spin></cube-spin>
+    <rotate-square2></rotate-square2>
   </div>
 </template>
 
 <script>
-  import {CubeSpin} from 'vue-loading-spinner'
+  import {RotateSquare2} from 'vue-loading-spinner'
   export default {
     components: {
-      CubeSpin
+      RotateSquare2
     }
   }
 </script>


### PR DESCRIPTION
Updating the example in the README with a working spinner. 
The example originally was using `CubeSpin` that it appears to not be included in the project anymore.
This can create confusion when trying it out.

I have changed it with `RotateSquare2`