### PR TITLE
bugfix/#42-Cube-amination-not-working

### DIFF
--- a/src/components/Cube.vue
+++ b/src/components/Cube.vue
@@ -22,7 +22,6 @@ export default {
     cubeStyles () {
       return {
         backgroundColor: this.background,
-        animationName: 'sk-cubemove',
         animationDuration: this.duration
       }
     },


### PR DESCRIPTION
Fixes #42

## What done
- remove animation name from computed. As it's style component we don't need to provide animation name here.

## Screen shots
![ezgif com-gif-maker](https://user-images.githubusercontent.com/67853959/155834903-1a7f9e3f-6604-4af2-8a0d-1c363f0fcfb5.gif)
